### PR TITLE
feat(hooks): :sparkles: 添加光标位置保存与恢复功能

### DIFF
--- a/src/hooks/useMsgInput.ts
+++ b/src/hooks/useMsgInput.ts
@@ -170,6 +170,15 @@ export const useMsgInput = (messageInputDom: Ref) => {
     topicKeyword
   )
 
+  // 在文件顶部添加新的响应式变量
+  const lastCursorPosition = ref<{
+    range: Range | null
+    selection: Selection | null
+  }>({
+    range: null,
+    selection: null
+  })
+
   watchEffect(() => {
     chatKey.value = chat.value.sendKey
     if (!ait.value && personList.value.length > 0) {
@@ -368,6 +377,12 @@ export const useMsgInput = (messageInputDom: Ref) => {
       return
     }
 
+    // 保存最后的光标位置
+    lastCursorPosition.value = {
+      range: range.cloneRange(),
+      selection
+    }
+
     /** 获取当前节点 */
     const curNode = range.endContainer
     /** 判断当前节点是否是文本节点 */
@@ -437,9 +452,18 @@ export const useMsgInput = (messageInputDom: Ref) => {
     if (isChinese.value) {
       return
     }
+
     // 先确保输入框获得焦点
     messageInputDom.value?.focus()
-    // 先获取并保存当前的编辑器范围
+
+    // 恢复上次保存的光标位置
+    if (lastCursorPosition.value.range && lastCursorPosition.value.selection) {
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      selection?.addRange(lastCursorPosition.value.range)
+    }
+
+    // 获取当前光标位置
     const { range: currentRange, selection: currentSelection } = getEditorRange()!
     editorRange.value = { range: currentRange, selection: currentSelection }
 
@@ -467,6 +491,15 @@ export const useMsgInput = (messageInputDom: Ref) => {
     insertNode(MsgEnum.AIT, item.name, {} as HTMLElement)
     triggerInputEvent(messageInputDom.value)
     ait.value = false
+
+    // 更新最后的光标位置
+    const newRange = getEditorRange()
+    if (newRange) {
+      lastCursorPosition.value = {
+        range: newRange.range.cloneRange(),
+        selection: newRange.selection
+      }
+    }
   }
 
   /** 处理点击 / 提及框事件 */
@@ -586,6 +619,17 @@ export const useMsgInput = (messageInputDom: Ref) => {
           )
           triggerInputEvent(messageInputDom.value)
         })
+      }
+    })
+
+    // 添加失焦事件监听
+    messageInputDom.value?.addEventListener('blur', () => {
+      const { range, selection } = getEditorRange()!
+      if (range && selection) {
+        lastCursorPosition.value = {
+          range: range.cloneRange(),
+          selection
+        }
       }
     })
   })


### PR DESCRIPTION
在useMsgInput钩子中引入了lastCursorPosition响应式变量，以保存和恢复用户的光标位置。添加了失焦事件监听器，确保在输入框失去焦点时记录当前光标位置。此功能提升了用户体验，确保在编辑过程中光标位置的一致性。

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat | 新增功能
- [x] 🐛 fix | 修复缺陷
- [ ] ♻️ refactor | 代码重构（不包括 bug 修复、功能新增）
- [ ] 💄 style | 代码格式（不影响功能，例如空格、分号等格式修正）
- [ ] 📦️ build | 构建流程、外部依赖变更（如升级 npm 包、修改 vite 配置等）
- [ ] 🚀 perf | 性能优化
- [ ] 📝 docs | 文档变更
- [ ] 🧪 test | 添加疏漏测试或已有测试改动
- [ ] ⚙️ ci | 修改 CI 配置、脚本
- [ ] ↩️ revert | 回滚 commit
- [ ] 🛠️ chore | 对构建过程或辅助工具和库的更改（不影响源文件、测试用例）

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
