### PR TITLE
chore(tauri): 确保 frontend_dist 存在避免出现 proc-macro panicked

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -2,7 +2,7 @@ use std::{env, fs, io};
 
 fn main() -> Result<(),  Box<dyn std::error::Error>> {
     ensure_frontend_dist()?;
-        tauri_build::build();
+    tauri_build::build();
 
     Ok(())
 }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,25 @@
-fn main() {
-    tauri_build::build()
+use std::{env, fs, io};
+
+fn main() -> Result<(),  Box<dyn std::error::Error>> {
+    ensure_frontend_dist()?;
+        tauri_build::build();
+
+    Ok(())
+}
+
+fn ensure_frontend_dist() -> Result<(),  Box<dyn std::error::Error>> {
+    let current_dir = env::current_dir()?;
+    let parent_dir = current_dir
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Cannot find parent directory!"))?;
+    let frontend_dist = parent_dir.join("dist");
+    
+    //  There should not be this directory.
+    let exists = frontend_dist.exists() && frontend_dist.is_dir();
+
+    if !exists {
+        fs::create_dir(&frontend_dist)?;
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat | 新增功能
- [ ] 🐛 fix | 修复缺陷
- [ ] ♻️ refactor | 代码重构（不包括 bug 修复、功能新增）
- [ ] 💄 style | 代码格式（不影响功能，例如空格、分号等格式修正）
- [x] 📦️ build | 构建流程、外部依赖变更（如升级 npm 包、修改 vite 配置等）
- [ ] 🚀 perf | 性能优化
- [ ] 📝 docs | 文档变更
- [ ] 🧪 test | 添加疏漏测试或已有测试改动
- [ ] ⚙️ ci | 修改 CI 配置、脚本
- [ ] ↩️ revert | 回滚 commit
- [ ] 🛠️ chore | 对构建过程或辅助工具和库的更改（不影响源文件、测试用例）

#### 🔀 变更说明 | Description of Change

当项目中没有 frontendDist 指定的文件夹时 tauri 总是对我大喊大叫！

<img width="791" alt="image" src="https://github.com/user-attachments/assets/7163a245-b6f8-47ab-b9d4-e928b89d2c94" />

在 `build.rs` 中检查如果不存在这个文件夹那么应该创建它！

是否应该根据 `tauri.config.json` 文件来创建？这似乎应该值得考虑我们是否需要为了这个问题而引入一个 json 解析器?

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
