### PR TITLE
fix(chat-editor): record cursor position correctly

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -51,6 +51,7 @@ module.exports = {
     'vue/multi-word-component-names': 'off', //关闭组件命名规则
     '@typescript-eslint/no-explicit-any': 'off', // 关闭any校验
     'no-redeclare': 2, //禁止重复声明变量
-    'eol-last': 'off' // 关闭行尾符（linebreak-style）的校验
+    'eol-last': 'off', // 关闭行尾符（linebreak-style）的校验
+    'vue/use-v-on-exact': 'off', // 如果使用了键盘事件，这个规则必须添加 exact,例如 `@keydown.exact`。该事件对 chat-editor 存在影响
   }
 }

--- a/src/components/rightBox/chatBox/ChatFooter.vue
+++ b/src/components/rightBox/chatBox/ChatFooter.vue
@@ -189,7 +189,17 @@ const emojiHandle = (item: string, type: 'emoji' | 'emoji-url' = 'emoji') => {
   if (!inp) return
 
   // 确保输入框有焦点
-  inp.focus()
+  MsgInputRef.value?.focus()
+
+  // 检查是否为 URL
+  const isUrl = (str: string) => {
+    try {
+      new URL(str)
+      return true
+    } catch {
+      return false
+    }
+  }
 
   // 尝试获取最后的编辑范围
   let lastEditRange: SelectionRange | null = MsgInputRef.value?.getLastEditRange()
@@ -222,7 +232,7 @@ const emojiHandle = (item: string, type: 'emoji' | 'emoji-url' = 'emoji') => {
   }
 
   // 根据内容类型插入不同的节点
-  if (checkIsUrl(item)) {
+  if (isUrl(item)) {
     // 如果是URL，创建图片元素并插入
     const imgElement = document.createElement('img')
     imgElement.src = item
@@ -244,13 +254,13 @@ const emojiHandle = (item: string, type: 'emoji' | 'emoji-url' = 'emoji') => {
   }
 
   // 记录新的选区位置
-  MsgInputRef.value?.recordSelectionRange()
+  MsgInputRef.value?.updateSelectionRange()
 
   // 触发输入事件
   triggerInputEvent(inp)
 
   // 保持焦点在输入框
-  inp.focus()
+  MsgInputRef.value?.focus()
 
   // 添加到最近使用表情列表
   updateRecentEmojis(item)


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] 🐛 fix | 修复缺陷
- [x] 🛠️ chore | 对构建过程或辅助工具和库的更改（不影响源文件、测试用例）

#### 🔀 变更说明 | Description of Change

处于长按输入后松开按键 `keydown` 事件未能捕获最后一次输入导致最后一位字符位置无法被记录，本次修复通过添加 `keyup` 事件兜底。以及添加 `compositionend` 修复中文输入被打断后的隐性 BUG。去除 `exact` 防止在连续 Shift 输入大写时无法记录光标位置。

- 长按输入（如连续输入字符）后，未正确更新光标位置
- 添加对复合输入事件（如长按、输入法）的光标位置验证

