### PR TITLE
fix(message): 将消息内容解析为文本而不当做 HTML 处理 #237

### DIFF
--- a/src/views/homeWindow/message/index.vue
+++ b/src/views/homeWindow/message/index.vue
@@ -45,8 +45,7 @@
             </n-flex>
 
             <n-flex align="center" justify="space-between">
-              <span class="text flex-1 leading-tight text-12px truncate" v-html="item.lastMsg.replace(':', '：')">
-              </span>
+              <span class="text flex-1 leading-tight text-12px truncate" v-text="item.lastMsg.replace(':', '：')" />
 
               <!-- 消息提示 -->
               <template v-if="item.muteNotification === 1 && !item.unreadCount">
@@ -254,6 +253,7 @@ onMounted(() => {
 
 <style lang="scss" scoped>
 @use '@/styles/scss/message';
+
 #image-no-data {
   @apply size-full mt-60px text-[--text-color] text-14px;
 }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] 🐛 fix | 修复缺陷

#### 🔀 变更说明 | Description of Change

将 `v-html` 更改为 `v-text`。该更改将无法在会话列表渲染任何 html 元素，若有需要，可能考虑更改消息存储结构