### PR TITLE
fix(chat): 隔离聊天窗口内部数据

### DIFF
--- a/src/layout/right/index.vue
+++ b/src/layout/right/index.vue
@@ -4,7 +4,7 @@
       <ActionBar :current-label="appWindow.label" />
 
       <!-- 需要判断当前路由是否是信息详情界面 -->
-      <ChatBox :active-item="activeItem" v-if="msgBoxShow && isChat && activeItem !== -1" />
+      <ChatBox :active-item="activeItem" :key="activeItem?.roomId" v-if="msgBoxShow && isChat && activeItem !== -1" />
 
       <Details :content="DetailsContent" v-else-if="detailsShow && isDetails && DetailsContent.type !== 'apply'" />
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] 🐛 fix | 修复缺陷

#### 🔀 变更说明 | Description of Change

在不同聊天会话之间切换时，聊天组件的内部实例被复用而未重新挂载或销毁，导致组件内的状态（如输入框的未提交文本、临时数据、光标位置等）未被清理和重置，从而错误地将上一会话的数据保留并展示于新会话中。

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
