### PR TITLE
Potential fix for code scanning alert no. 35: Client-side cross-site scripting

### DIFF
--- a/src/utils/AvatarUtils.ts
+++ b/src/utils/AvatarUtils.ts
@@ -36,6 +36,10 @@ export class AvatarUtils {
     if (AvatarUtils.isDefaultAvatar(avatar)) {
       return `/avatar/${avatar}.webp`
     }
-    return avatar
+    // Only allow HTTPS URLs, otherwise fall back to default avatar
+    if (typeof avatar === 'string' && avatar.trim().toLowerCase().startsWith('https://')) {
+      return avatar;
+    }
+    return '/avatar/001.png';
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/HuLaSpark/HuLa/security/code-scanning/35](https://github.com/HuLaSpark/HuLa/security/code-scanning/35)

To fix this Cross-Site Scripting (XSS) vulnerability, we must ensure that the value assigned to the `imgNode.src` attribute is absolutely safe and cannot contain malicious content. The safest way is to enforce a strict whitelist policy for avatar URLs: only allow application-controlled (static) files, or, for external URLs, ensure a safe protocol (e.g., `'https://'`) and never allow executable schemes like `javascript:` or `data:`.

The best and most robust fix is to enforce the following logic in `AvatarUtils.getAvatarUrl()`:
- If the avatar is a valid default avatar (`001`-`022`), return the internal path as before.
- If the avatar is a URL, only allow `https://` or a specific whitelisted set of hostnames. Otherwise, return the fallback avatar.

Alternatively, add a strong protocol check at the assignment site before setting `imgNode.src`.

Since you can only change the files and code regions shown, the most appropriate place is to update `AvatarUtils.getAvatarUrl()` in `src/utils/AvatarUtils.ts` to always return a safe URL—falling back to the default if the input is not a valid internal avatar string or a strictly-allowed `https://...` pattern.

**Changes needed:**
- Update `AvatarUtils.getAvatarUrl()` to check if `avatar` is a "default file" avatar or a secure HTTPS URL (`/^https:\/\/[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,}.*$/`). Otherwise, return the application's default avatar.
    - If external URLs to other protocols or hosts are to be allowed, set up a whitelist.
    - Consider precluding "data:", "javascript:", and any non-https protocols outright.

No new methods or imports are required—the check is a simple regex or protocol-scheme check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
