### PR TITLE
Potential fix for code scanning alert no. 42: Incomplete multi-character sanitization

### DIFF
--- a/src/hooks/useMsgInput.ts
+++ b/src/hooks/useMsgInput.ts
@@ -314,7 +314,13 @@ export const useMsgInput = (messageInputDom: Ref) => {
 
       const doc = parseHtmlSafely(html)
       if (!doc || !doc.body) {
-        return html.replace(/<[^>]*>/g, '').trim()
+        let sanitized = html;
+        let previous;
+        do {
+          previous = sanitized;
+          sanitized = sanitized.replace(/<[^>]*>/g, '');
+        } while (sanitized !== previous);
+        return sanitized.trim();
       }
 
       const replyDiv = doc.querySelector('#replyDiv')


### PR DESCRIPTION
Potential fix for [https://github.com/HuLaSpark/HuLa/security/code-scanning/42](https://github.com/HuLaSpark/HuLa/security/code-scanning/42)

To properly sanitize HTML and avoid incomplete tag removal (especially dangerous ones like `<script>`), either a well-tested library (e.g., `sanitize-html`) or repeated regex replacement until the string stabilizes should be used.  

- Since the codebase is TypeScript and likely runs in a browser, the simplest local fix is to repeatedly apply the regex until no matches remain, preventing incomplete removals.
- Alternatively, a DOM parser can reliably remove tags but is already attempted by the earlier code (via `parseHtmlSafely`).
- The fix should replace line 317 with a loop that removes tags until none are left.
- No additional imports are required for this repeated regex approach.
- No changes needed elsewhere in the shown code snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
