### PR TITLE
fix(nsis): per-machine installer elevation and uninstall handling

### DIFF
--- a/src-tauri/template/installer.nsi
+++ b/src-tauri/template/installer.nsi
@@ -96,7 +96,7 @@ VIAddVersionKey "ProductVersion" "${VERSION}"
 
 ; Handle install mode, `perUser`, `perMachine` or `both`
 !if "${INSTALLMODE}" == "perMachine"
-  RequestExecutionLevel highest
+  RequestExecutionLevel admin
 !endif
 
 !if "${INSTALLMODE}" == "currentUser"

--- a/src-tauri/template/utils.nsh
+++ b/src-tauri/template/utils.nsh
@@ -48,6 +48,7 @@
         Pop $R0
         Sleep 500
         ${If} $R0 = 0
+        ${OrIf} $R0 = 2
           Goto app_check_done_${UniqueID}
         ${Else}
           IfSilent silent_${UniqueID} ui_${UniqueID}


### PR DESCRIPTION
…, per-machine installer not requesting elevation when run by non-admin users

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat | 新增功能
- [x] 🐛 fix | 修复缺陷
- [ ] ♻️ refactor | 代码重构（不包括 bug 修复、功能新增）
- [ ] 💄 style | 代码格式（不影响功能，例如空格、分号等格式修正）
- [ ] 📦️ build | 构建流程、外部依赖变更（如升级 npm 包、修改 vite 配置等）
- [ ] 🚀 perf | 性能优化
- [ ] 📝 docs | 文档变更
- [ ] 🧪 test | 添加疏漏测试或已有测试改动
- [ ] ⚙️ ci | 修改 CI 配置、脚本
- [ ] ↩️ revert | 回滚 commit
- [ ] 🛠️ chore | 对构建过程或辅助工具和库的更改（不影响源文件、测试用例）

#### 🔀 变更说明 | Description of Change

Fixes NSIS installer issues by ensuring per-machine installs request elevation for non-admin users, and preventing uninstall failures when the app is manually closed.

#### 📝 补充信息 | Additional Information

Changes are aligned with upstream Tauri fixes:

installer.nsi: https://github.com/tauri-apps/tauri/commit/f94af90359ec8b01138ae542391caa704ec18ca8

utils.nsh: https://github.com/tauri-apps/tauri/commit/9a192263693d71123a9953e2a6ee60fad07500b4
