### PR TITLE
chore(tooling): update VSCode tsdk setting and ignore .vscode in lint-staged

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -10,7 +10,7 @@ export default {
     (filenames) => {
       const filteredFiles = filenames.filter(
         (f) =>
-          !f.includes('src-tauri/') && !f.includes('tauri-plugin-hula/') && !f.includes('public/') && !f.endsWith('.d.ts')
+          !f.includes('src-tauri/') && !f.includes('tauri-plugin-hula/') && !f.includes('public/') && !f.endsWith('.d.ts') && !f.includes('.vscode/')
       )
       return filteredFiles.length > 0
         ? `biome check --write --unsafe ${filteredFiles.map((f) => path.relative(process.cwd(), f)).join(' ')}`

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     ".vscode/tailwindcss.json"
   ],
   "java.configuration.updateBuildConfiguration": "disabled",
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "i18n-ally.autoDetection": false,
   "i18n-ally.displayLanguage": "zh",
   "i18n-ally.namespace": true,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🛠️ chore | 对构建过程或辅助工具和库的更改（不影响源文件、测试用例）

`lintstage` 将 `biome.json` 忽略的 `.vscode` 文件夹给到 biome 导致每次改动 .vscode 后 `git commit` 都会发生 `✖ No files were processed in the specified paths.` 错误