### PR TITLE
fix: override nopt dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,8 @@
     "overrides": {
       "conventional-changelog-conventionalcommits": "8.0.0",
       "lodash": "4.18.1",
-      "lodash-es": "4.18.1"
+      "lodash-es": "4.18.1",
+      "nopt": "9.0.0"
     },
     "ignoredBuiltDependencies": ["@parcel/watcher", "esbuild", "sharp", "tlbs-map-vue", "vue-demi"]
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   conventional-changelog-conventionalcommits: 8.0.0
   lodash: 4.18.1
   lodash-es: 4.18.1
+  nopt: 9.0.0
 
 importers:
 
@@ -1853,9 +1854,9 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
-  abbrev@2.0.0:
-    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+  abbrev@4.0.0:
+    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -3526,9 +3527,9 @@ packages:
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
-  nopt@7.2.1:
-    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+  nopt@9.0.0:
+    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   normalize-package-data@7.0.1:
@@ -6253,7 +6254,7 @@ snapshots:
     dependencies:
       vue: 3.5.33(typescript@6.0.3)
 
-  abbrev@2.0.0: {}
+  abbrev@4.0.0: {}
 
   acorn@8.16.0: {}
 
@@ -7536,7 +7537,7 @@ snapshots:
       editorconfig: 1.0.7
       glob: 10.5.0
       js-cookie: 3.0.5
-      nopt: 7.2.1
+      nopt: 9.0.0
 
   js-cookie@3.0.5: {}
 
@@ -7935,9 +7936,9 @@ snapshots:
 
   node-releases@2.0.38: {}
 
-  nopt@7.2.1:
+  nopt@9.0.0:
     dependencies:
-      abbrev: 2.0.0
+      abbrev: 4.0.0
 
   normalize-package-data@7.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- add pnpm override for nopt 9.0.0
- refresh lockfile entries for nopt and abbrev

## Validation
- pnpm install --frozen-lockfile
- pnpm check
- pnpm test:run

## Notes
- .agents/ remains untracked and is not included in this PR.