### PR TITLE
fix(contact): isolate request unread state between PC accounts

### DIFF
--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -28,6 +28,7 @@ import { info as logInfo } from '@tauri-apps/plugin-log'
 import { ensureAppStateReady } from '@/utils/AppStateReady'
 import { useI18nGlobal } from '../services/i18n'
 import { useInitialSyncStore } from '@/stores/initialSync'
+import { useContactStore } from '@/stores/contacts'
 import { openExternalUrl } from './useLinkSegments'
 import { TokenManager } from '@/utils/TokenManager'
 
@@ -45,6 +46,7 @@ export const useLogin = () => {
   const userStore = useUserStore()
   const loginHistoriesStore = useLoginHistoriesStore()
   const initialSyncStore = useInitialSyncStore()
+  const contactStore = useContactStore()
   const { createWebviewWindow } = useWindow()
 
   const { t } = useI18nGlobal()
@@ -75,6 +77,13 @@ export const useLogin = () => {
       delete groupStore.userListMap[key]
     }
     console.log('[useLogin] Message cache has been cleared')
+  }
+
+  /** 清理当前账号的好友申请状态，避免窗口交接或异步响应造成红点串号 */
+  const clearAccountApplyState = () => {
+    if (!isDesktop()) return
+    globalStore.resetAccountApplyState()
+    contactStore.resetAccountState()
   }
 
   /**
@@ -124,6 +133,7 @@ export const useLogin = () => {
    */
   const logout = async () => {
     globalStore.updateCurrentSessionRoomId('')
+    clearAccountApplyState()
 
     const sendLogoutEvent = async () => {
       // ws 退出连接
@@ -246,6 +256,7 @@ export const useLogin = () => {
 
     // 清空 localStorage，防止页面刷新时恢复旧账号数据
     clearUserLocalStorage()
+    clearAccountApplyState()
 
     // 清空消息缓存，避免旧消息混入新账号
     clearMessageCache()
@@ -273,6 +284,9 @@ export const useLogin = () => {
     }
     userStore.userInfo = account
     loginHistoriesStore.addLoginHistory(account)
+    if (isDesktop()) {
+      await contactStore.getApplyUnReadCount()
+    }
     // 初始化表情列表并在后台预取本地缓存（使用 worker + 并发限制）
     void emojiStore.initEmojis().catch(() => {
       void logInfo('[login] 初始化表情失败')

--- a/src/stores/contacts.ts
+++ b/src/stores/contacts.ts
@@ -5,6 +5,7 @@ import { RequestNoticeAgreeStatus } from '@/services/types'
 import { useGlobalStore } from '@/stores/global'
 import { useFeedStore } from '@/stores/feed'
 import { useGroupStore } from '@/stores/group'
+import { useUserStore } from '@/stores/user'
 import {
   deleteFriend,
   getFriendPage,
@@ -19,6 +20,7 @@ export const useContactStore = defineStore(StoresEnum.CONTACTS, () => {
   const globalStore = useGlobalStore()
   const feedStore = useFeedStore()
   const groupStore = useGroupStore()
+  const userStore = useUserStore()
 
   /** 联系人列表 */
   const contactsList = ref<FriendItem[]>([])
@@ -69,9 +71,13 @@ export const useContactStore = defineStore(StoresEnum.CONTACTS, () => {
    * 更新全局store中的未读计数
    */
   const getApplyUnReadCount = async () => {
+    const requestUid = userStore.userInfo?.uid
+    if (!requestUid) return
+
     const res: any = await getNoticeUnreadCount()
-    if (!res) return
-    // 更新全局store中的未读计数
+    if (!res || userStore.userInfo?.uid !== requestUid) return
+
+    // 仅允许当前账号的响应更新未读计数，避免切换账号时旧请求覆盖新状态
     globalStore.unReadMark.newFriendUnreadCount = res.unReadCount4Friend
     globalStore.unReadMark.newGroupUnreadCount = res.unReadCount4Group
 
@@ -211,6 +217,14 @@ export const useContactStore = defineStore(StoresEnum.CONTACTS, () => {
     await getContactList(true)
   }
 
+  /** 清理账号相关的联系人和申请状态，避免切换账号时复用旧数据 */
+  const resetAccountState = () => {
+    contactsList.value = []
+    requestFriendsList.value = []
+    contactsOptions.value = { isLast: false, isLoading: false, cursor: '' }
+    applyPageOptions.value = { isLast: false, cursor: '', pageNo: 1 }
+  }
+
   return {
     getContactList,
     getApplyPage,
@@ -221,6 +235,7 @@ export const useContactStore = defineStore(StoresEnum.CONTACTS, () => {
     applyPageOptions,
     onDeleteFriend,
     onHandleInvite,
-    deleteContact
+    deleteContact,
+    resetAccountState
   }
 })

--- a/src/stores/global.ts
+++ b/src/stores/global.ts
@@ -164,6 +164,13 @@ export const useGlobalStore = defineStore(
       currentSessionRoomId.value = id
     }
 
+    /** 清理账号相关的申请未读状态，避免切换账号时共享旧账号红点 */
+    const resetAccountApplyState = () => {
+      unReadMark.newFriendUnreadCount = 0
+      unReadMark.newGroupUnreadCount = 0
+      currentSelectedContact.value = undefined
+    }
+
     return {
       unReadMark,
       currentSession,
@@ -178,6 +185,7 @@ export const useGlobalStore = defineStore(
       setTipVisible,
       updateGlobalUnreadCount,
       updateCurrentSessionRoomId,
+      resetAccountApplyState,
       currentSessionRoomId
     }
   },


### PR DESCRIPTION
Refs #520

#### 💻 变更类型 | Change Type

- [ ] ✨ feat | 新增功能
- [x] 🐛 fix | 修复缺陷
- [ ] ♻️ refactor | 代码重构（不包括 bug 修复、功能新增）
- [ ] 💄 style | 代码格式（不影响功能，例如空格、分号等格式修正）
- [ ] 📦️ build | 构建流程、外部依赖变更（如升级 npm 包、修改 vite 配置等）
- [ ] 🚀 perf | 性能优化
- [ ] 📝 docs | 文档变更
- [ ] 🧪 test | 添加疏漏测试或已有测试改动
- [ ] ⚙️ ci | 修改 CI 配置、脚本
- [ ] ↩️ revert | 回滚 commit
- [ ] 🛠️ chore | 对构建过程或辅助工具和库的更改（不影响源文件、测试用例）

#### 🔀 变更说明 | Description of Change

- PC 端退出和切换账号时清理好友、群申请未读状态
- 清理旧账号的联系人列表、申请列表和分页状态
- 新账号初始化完成后主动获取当前账号的申请未读数
- 未读数请求返回时校验当前用户 UID，避免旧账号响应覆盖新账号状态
- 相关登录清理逻辑仅在 PC 端执行

#### 📝 补充信息 | Additional Information

本次仅处理 PC 端账号切换时的申请红点状态隔离，不包含移动端事件分发问题，因此使用 `Refs #520`，不自动关闭 Issue。

验证结果：

- `pnpm exec biome check src/stores/global.ts src/stores/contacts.ts src/hooks/useLogin.ts`
- `pnpm exec vue-tsc --noEmit`
- `git diff --check`

以上检查均通过。

`pnpm test:run` 当前提示 `No test files found`，仓库暂无匹配的单元测试文件。